### PR TITLE
(chore): Removing maintainers home path

### DIFF
--- a/today
+++ b/today
@@ -10,7 +10,7 @@ fi
 
 # Load configuration file
 if [ -f "$CONFIG_FILE" ]; then
-  # shellcheck source=/home/alabhya/.today.conf
+  # shellcheck source=/dev/null
   source "$CONFIG_FILE"
 fi
 


### PR DESCRIPTION
Small cleanup PR to remove the maintainers home path from the shellcheck comment. The shellcheck validation is not contingent on being able to source the file at runtime since it's not a library so setting it to `/dev/null` will have no effect. [Source](https://www.shellcheck.net/wiki/SC1090#exceptions)