### PR TITLE
POSIXification lets today run on multiple shells

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,7 @@ curl -o /usr/local/bin/today https://raw.githubusercontent.com/alabhyajindal/tod
 chmod +x /usr/local/bin/today
 ```
 
-Create a directory for your daily notes:
-
-```
-mkdir -p ~/Documents/Journal
-```
-
-Or, create a directory elsewhere and specify it in `~/.today.conf`
-
+By default `today` will create and use the directory `~/Documents/Journal/` for your daily notes, but you could use or create another directory and specify it in `~/.today.conf`.
 
 ### Usage
 

--- a/today
+++ b/today
@@ -22,8 +22,8 @@ fi
 
 # Check if the directory exists
 if [ -d "$DIRECTORY" ]; then
-  MONTH_PATH="$DIRECTORY/""$MONTH_DIR_NAME"
-  FILE_PATH="$DIRECTORY/""$MONTH_DIR_NAME/""$FILE_NAME"
+  MONTH_PATH="$DIRECTORY/$MONTH_DIR_NAME"
+  FILE_PATH="$DIRECTORY/$MONTH_DIR_NAME/$FILE_NAME"
 
   # Create month directory if missing
   if [ ! -d "$MONTH_PATH" ]; then

--- a/today
+++ b/today
@@ -17,24 +17,18 @@ if [ -f "$CONFIG_FILE" ]; then
   . "$CONFIG_FILE"
 fi
 
-# Exit if missing directory
-if [ ! -d "$DIRECTORY" ]; then
-  echo "Missing directory." >&2
-  exit 1
-fi
-
+# Create potentially missing directories
+mkdir -p "$DIRECTORY"
 MONTH_PATH="$DIRECTORY/$MONTH_DIR_NAME"
+mkdir -p "$MONTH_PATH"
 FILE_PATH="$DIRECTORY/$MONTH_DIR_NAME/$FILE_NAME"
 
-# Create month directory if missing
-mkdir -p "$MONTH_PATH"
-
-# Open note and exit if note exits
-if [ -f "$FILE_PATH" ]; then
-  exec "${EDITOR:-vim}" "$FILE_PATH"
+# Create note if is doesn't exist
+if [ ! -f "$FILE_PATH" ]; then
+  printf '%s' "$TEMPLATE" > "$FILE_PATH"
 fi
 
-# Create and open note if it doesn't exist
-printf '%s' "$TEMPLATE" > "$FILE_PATH"
+# Open [new or existing] note, and
+# let the editor handle the exit code
 exec "${EDITOR:-vim}" "$FILE_PATH"
 

--- a/today
+++ b/today
@@ -12,10 +12,8 @@ if [ ! -f "$CONFIG_FILE" ]; then
 fi
 
 # Load configuration file
-if [ -f "$CONFIG_FILE" ]; then
-  # shellcheck source=/dev/null
-  . "$CONFIG_FILE"
-fi
+# shellcheck source=/dev/null
+. "$CONFIG_FILE"
 
 # Create potentially missing directories
 mkdir -p "$DIRECTORY"

--- a/today
+++ b/today
@@ -38,7 +38,7 @@ if [ -d "$DIRECTORY" ]; then
     fi
 
     # Create and open note if it doesn't exist
-    echo -e "$TEMPLATE" > "$FILE_PATH"
+    printf '%s' "$TEMPLATE" > "$FILE_PATH"
     "${EDITOR:-vim}" "$FILE_PATH"
     exit 0
   fi

--- a/today
+++ b/today
@@ -4,7 +4,7 @@ CONFIG_FILE="$HOME/.today.conf"
 
 # Exit if missing configuration
 if [ ! -f "$CONFIG_FILE" ]; then
-  echo -e "Missing configuration file.\n"
+  echo "Missing configuration file."
   exit 1
 fi
 
@@ -16,7 +16,7 @@ fi
 
 # Exit if missing directory
 if [ ! -d "$DIRECTORY" ]; then
-  echo -e "Missing directory.\n"
+  echo "Missing directory."
   exit 1
 fi
 

--- a/today
+++ b/today
@@ -2,6 +2,9 @@
 
 CONFIG_FILE="$HOME/.today.conf"
 
+# Exit on errors
+set -e
+
 # Exit if missing configuration
 if [ ! -f "$CONFIG_FILE" ]; then
   echo "Missing configuration file." >&2

--- a/today
+++ b/today
@@ -26,21 +26,17 @@ if [ -d "$DIRECTORY" ]; then
   FILE_PATH="$DIRECTORY/$MONTH_DIR_NAME/$FILE_NAME"
 
   # Create month directory if missing
-  if [ ! -d "$MONTH_PATH" ]; then
-    mkdir -p "$MONTH_PATH"
-  fi
+  mkdir -p "$MONTH_PATH"
 
   # Open note and exit if note exits
   if [ -d "$MONTH_PATH" ]; then
     if [ -f "$FILE_PATH" ]; then
-      "${EDITOR:-vim}" "$FILE_PATH"
-      exit 0
+      exec "${EDITOR:-vim}" "$FILE_PATH"
     fi
 
     # Create and open note if it doesn't exist
     printf '%s' "$TEMPLATE" > "$FILE_PATH"
-    "${EDITOR:-vim}" "$FILE_PATH"
-    exit 0
+    exec "${EDITOR:-vim}" "$FILE_PATH"
   fi
 fi
 

--- a/today
+++ b/today
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 CONFIG_FILE="$HOME/.today.conf"
 
@@ -11,7 +11,7 @@ fi
 # Load configuration file
 if [ -f "$CONFIG_FILE" ]; then
   # shellcheck source=/dev/null
-  source "$CONFIG_FILE"
+  . "$CONFIG_FILE"
 fi
 
 # Exit if missing directory

--- a/today
+++ b/today
@@ -23,21 +23,18 @@ if [ ! -d "$DIRECTORY" ]; then
   exit 1
 fi
 
-# Check if the directory exists
-if [ -d "$DIRECTORY" ]; then
-  MONTH_PATH="$DIRECTORY/$MONTH_DIR_NAME"
-  FILE_PATH="$DIRECTORY/$MONTH_DIR_NAME/$FILE_NAME"
+MONTH_PATH="$DIRECTORY/$MONTH_DIR_NAME"
+FILE_PATH="$DIRECTORY/$MONTH_DIR_NAME/$FILE_NAME"
 
-  # Create month directory if missing
-  mkdir -p "$MONTH_PATH"
+# Create month directory if missing
+mkdir -p "$MONTH_PATH"
 
-  # Open note and exit if note exits
-  if [ -f "$FILE_PATH" ]; then
-    exec "${EDITOR:-vim}" "$FILE_PATH"
-  fi
-
-  # Create and open note if it doesn't exist
-  printf '%s' "$TEMPLATE" > "$FILE_PATH"
+# Open note and exit if note exits
+if [ -f "$FILE_PATH" ]; then
   exec "${EDITOR:-vim}" "$FILE_PATH"
 fi
+
+# Create and open note if it doesn't exist
+printf '%s' "$TEMPLATE" > "$FILE_PATH"
+exec "${EDITOR:-vim}" "$FILE_PATH"
 

--- a/today
+++ b/today
@@ -32,14 +32,12 @@ if [ -d "$DIRECTORY" ]; then
   mkdir -p "$MONTH_PATH"
 
   # Open note and exit if note exits
-  if [ -d "$MONTH_PATH" ]; then
-    if [ -f "$FILE_PATH" ]; then
-      exec "${EDITOR:-vim}" "$FILE_PATH"
-    fi
-
-    # Create and open note if it doesn't exist
-    printf '%s' "$TEMPLATE" > "$FILE_PATH"
+  if [ -f "$FILE_PATH" ]; then
     exec "${EDITOR:-vim}" "$FILE_PATH"
   fi
+
+  # Create and open note if it doesn't exist
+  printf '%s' "$TEMPLATE" > "$FILE_PATH"
+  exec "${EDITOR:-vim}" "$FILE_PATH"
 fi
 

--- a/today
+++ b/today
@@ -5,13 +5,8 @@ CONFIG_FILE="$HOME/.today.conf"
 # Exit on errors
 set -e
 
-# Exit if missing configuration
-if [ ! -f "$CONFIG_FILE" ]; then
-  echo "Missing configuration file." >&2
-  exit 1
-fi
-
-# Load configuration file
+# Load configuration file (the source/. command will handle
+# the error message if configuration file is missing)
 # shellcheck source=/dev/null
 . "$CONFIG_FILE"
 
@@ -23,7 +18,10 @@ FILE_PATH="$DIRECTORY/$MONTH_DIR_NAME/$FILE_NAME"
 
 # Create note if is doesn't exist
 if [ ! -f "$FILE_PATH" ]; then
-  printf '%s' "$TEMPLATE" > "$FILE_PATH"
+  cat <<EOF >"$FILE_PATH"
+$TEMPLATE
+
+EOF
 fi
 
 # Open [new or existing] note, and

--- a/today
+++ b/today
@@ -4,7 +4,7 @@ CONFIG_FILE="$HOME/.today.conf"
 
 # Exit if missing configuration
 if [ ! -f "$CONFIG_FILE" ]; then
-  echo "Missing configuration file."
+  echo "Missing configuration file." >&2
   exit 1
 fi
 
@@ -16,7 +16,7 @@ fi
 
 # Exit if missing directory
 if [ ! -d "$DIRECTORY" ]; then
-  echo "Missing directory."
+  echo "Missing directory." >&2
   exit 1
 fi
 


### PR DESCRIPTION
The  `bash` shell is big and slow compared to some other shells, but `echo -e` is a bashism, so I started by eliminating the `-e` thing. It then occurred to me that `echo -e "string\n"` is the same as `echo string`, so the two first occurances sort of eliminated themselves. The second was solved by a here-doc.

POSIX shell uses `.` instead of `source`, and suddenly the script was POSIX compatible, meaning that it will run on `sh`, `ksh` and `dash` as a minimum, all of which are smaller and faster than `bash` (I'm pretty sure it will also run on `zsh`, although I haven't tried). So I changed the shebang line from `#!/usr/bin/env bash` to `#!/bin/sh` so that the script will automatically use the shell that people are using for `sh`, which should be POSIX compatible.

Then I noticed that files and directories are double-checked for existence, when one check is enough. And since `mkdir -p` is itself doing the equivalent of `if [ ! -d …`, there is no need to do it in the shell code too. In order to make sure the script exits on errors, I have also added a `set -e` at the top of the script.

Lastly I have removed a couple of unnecessary quotes around environment variables, and made sure that error messages are printed to standard error (`>&2`).

Oh yeah, and by letting the script end with `exec "$EDITOR"`, the editor will handle any errors on its part (like missing permissions et cetera) and exit with a valid error code).

Bottom line: The script is quite compact now, and it will run on any POSIX compliant shell, as the following snippet will confirm:

```sh
for shell in bash dash ksh sh; do
  shellcheck -s "$shell" today
done
```

Cheers.
